### PR TITLE
Setting charge time and filter registers in MPR121 to increase gain and ADC resolution

### DIFF
--- a/arduino/touch-twist-poke-v0.2/touch-twist-poke-v0.2.ino
+++ b/arduino/touch-twist-poke-v0.2/touch-twist-poke-v0.2.ino
@@ -128,7 +128,13 @@ void setup() {
       MPRTwo_connected = true;
     }
   }
-
+  
+  // Setting charge time to 8 uS and increasing the number of samples in the first filter stage
+  MPROne.writeRegister(MPR121_CONFIG1, 0b11010000);
+  MPROne.writeRegister(MPR121_CONFIG2, 0b10000100);
+  
+  MPRTwo.writeRegister(MPR121_CONFIG1, 0b11010000);
+  MPRTwo.writeRegister(MPR121_CONFIG2, 0b10000100);
 
   Serial.println("done :)");
 


### PR DESCRIPTION
This change is in conjunction with reducing input impedance by probing the plants directly and also keeping a watch on parasitic capacitance effects from the soil and pots into the structure.